### PR TITLE
Implement lock summaries for interprocedural analysis in LockOwnership

### DIFF
--- a/llvm/include/llvm/Analysis/LockOwnership.h
+++ b/llvm/include/llvm/Analysis/LockOwnership.h
@@ -89,9 +89,11 @@ private:
     BBStateMap InStates, OutStates;
     LockStateTy ExitState;
     // Lock summary for interprocedural analysis:
-    // Set of locks that may be unlocked and not relocked in this function
+    // Set of locks that are locked at entry but may be unlocked (on at least
+    // one path) and not relocked before exit
     SmallPtrSet<const Value *, 4> MayUnlock;
-    // Set of locks that are locked but weren't locked at entry
+    // Set of locks that are locked at exit (on all paths) but were not locked
+    // at entry (on all paths) - i.e., newly acquired locks
     SmallPtrSet<const Value *, 4> MustLock;
   };
   SmallDenseMap<const Function *, FuncStateTy> FuncStates;

--- a/llvm/include/llvm/Analysis/LockOwnership.h
+++ b/llvm/include/llvm/Analysis/LockOwnership.h
@@ -88,6 +88,11 @@ private:
   struct FuncStateTy {
     BBStateMap InStates, OutStates;
     LockStateTy ExitState;
+    // Lock summary for interprocedural analysis:
+    // Set of locks that may be unlocked and not relocked in this function
+    SmallPtrSet<const Value *, 4> MayUnlock;
+    // Set of locks that are locked but weren't locked at entry
+    SmallPtrSet<const Value *, 4> MustLock;
   };
   SmallDenseMap<const Function *, FuncStateTy> FuncStates;
 

--- a/llvm/lib/Analysis/LockOwnership.cpp
+++ b/llvm/lib/Analysis/LockOwnership.cpp
@@ -307,19 +307,27 @@ void LockOwnershipInfo::buildSummary(const Function *F, bool InstrToLockFlag) {
   MayUnlock.clear();
   MustLock.clear();
   
-  // MayUnlock: Locks that are in entry state but not in exit state
+  // MayUnlock: Locks that are locked at entry but not locked at exit
   for (const auto &[Lock, State] : EntryState) {
-    if (State.IsLocked && ExitState.find(Lock) == ExitState.end()) {
-      MayUnlock.insert(Lock);
-      LLVM_DEBUG(dbgs() << "  MayUnlock: " << *Lock << "\n");
+    if (State.IsLocked) {
+      const auto ExitIt = ExitState.find(Lock);
+      // Lock is unlocked if it doesn't exist in exit state or exists but is not locked
+      if (ExitIt == ExitState.end() || !ExitIt->second.IsLocked) {
+        MayUnlock.insert(Lock);
+        LLVM_DEBUG(dbgs() << "  MayUnlock: " << *Lock << "\n");
+      }
     }
   }
   
-  // MustLock: Locks that are in exit state but not in entry state
+  // MustLock: Locks that are locked at exit but were not locked at entry
   for (const auto &[Lock, State] : ExitState) {
-    if (State.IsLocked && EntryState.find(Lock) == EntryState.end()) {
-      MustLock.insert(Lock);
-      LLVM_DEBUG(dbgs() << "  MustLock: " << *Lock << "\n");
+    if (State.IsLocked) {
+      const auto EntryIt = EntryState.find(Lock);
+      // Lock is newly acquired if it doesn't exist in entry state or exists but is not locked
+      if (EntryIt == EntryState.end() || !EntryIt->second.IsLocked) {
+        MustLock.insert(Lock);
+        LLVM_DEBUG(dbgs() << "  MustLock: " << *Lock << "\n");
+      }
     }
   }
 

--- a/llvm/lib/Analysis/LockOwnership.cpp
+++ b/llvm/lib/Analysis/LockOwnership.cpp
@@ -307,7 +307,7 @@ void LockOwnershipInfo::buildSummary(const Function *F, bool InstrToLockFlag) {
   MayUnlock.clear();
   MustLock.clear();
 
-  // MayUnlock: Locks that are locked at entry but not locked at exit
+  // MayUnlock: Locks that are locked at entry but either not locked or absent at exit
   for (const auto &[Lock, State] : EntryState) {
     if (State.IsLocked) {
       const auto ExitIt = ExitState.find(Lock);
@@ -319,7 +319,7 @@ void LockOwnershipInfo::buildSummary(const Function *F, bool InstrToLockFlag) {
     }
   }
 
-  // MustLock: Locks that are locked at exit but were not locked at entry
+  // MustLock: Locks that are locked at exit but were either not locked or absent at entry
   for (const auto &[Lock, State] : ExitState) {
     if (State.IsLocked) {
       const auto EntryIt = EntryState.find(Lock);

--- a/llvm/lib/Analysis/LockOwnership.cpp
+++ b/llvm/lib/Analysis/LockOwnership.cpp
@@ -192,12 +192,20 @@ bool LockOwnershipInfo::applyTransferFunc(const BasicBlock *BB,
       // Get a function state if it exists
       const auto FuncStateIt = FuncStates.find(CalledFunc);
       if (FuncStateIt != FuncStates.end()) {
-        // Update the current state with callee's exit state
-        for (const auto &[Lock, State] : FuncStateIt->second.ExitState) {
-          if (State.IsLocked)
-            handleLock(InState, I, Lock);
-          else
+        // Use lock summaries to update the current state:
+        // 1. Remove locks that the callee may unlock
+        for (const Value *Lock : FuncStateIt->second.MayUnlock) {
+          const auto It = InState.find(Lock);
+          if (It != InState.end()) {
+            LLVM_DEBUG(dbgs() << "  Removing lock (MayUnlock): " << *Lock << "\n");
             handleUnlock(InState, I, Lock);
+          }
+        }
+        
+        // 2. Add locks that the callee must lock
+        for (const Value *Lock : FuncStateIt->second.MustLock) {
+          LLVM_DEBUG(dbgs() << "  Adding lock (MustLock): " << *Lock << "\n");
+          handleLock(InState, I, Lock);
         }
       }
       continue;
@@ -288,6 +296,30 @@ void LockOwnershipInfo::buildSummary(const Function *F, bool InstrToLockFlag) {
           ExitState = intersectLockStates(ExitState, OutIt->second);
         }
       }
+    }
+  }
+
+  // 5. Compute lock summaries for interprocedural analysis
+  const LockStateTy &EntryState = InStates[&EntryBB];
+  SmallPtrSet<const Value *, 4> &MayUnlock = FuncStateIt->second.MayUnlock;
+  SmallPtrSet<const Value *, 4> &MustLock = FuncStateIt->second.MustLock;
+  
+  MayUnlock.clear();
+  MustLock.clear();
+  
+  // MayUnlock: Locks that are in entry state but not in exit state
+  for (const auto &[Lock, State] : EntryState) {
+    if (State.IsLocked && ExitState.find(Lock) == ExitState.end()) {
+      MayUnlock.insert(Lock);
+      LLVM_DEBUG(dbgs() << "  MayUnlock: " << *Lock << "\n");
+    }
+  }
+  
+  // MustLock: Locks that are in exit state but not in entry state
+  for (const auto &[Lock, State] : ExitState) {
+    if (State.IsLocked && EntryState.find(Lock) == EntryState.end()) {
+      MustLock.insert(Lock);
+      LLVM_DEBUG(dbgs() << "  MustLock: " << *Lock << "\n");
     }
   }
 

--- a/llvm/lib/Analysis/LockOwnership.cpp
+++ b/llvm/lib/Analysis/LockOwnership.cpp
@@ -201,7 +201,7 @@ bool LockOwnershipInfo::applyTransferFunc(const BasicBlock *BB,
             handleUnlock(InState, I, Lock);
           }
         }
-        
+
         // 2. Add locks that the callee must lock
         for (const Value *Lock : FuncStateIt->second.MustLock) {
           LLVM_DEBUG(dbgs() << "  Adding lock (MustLock): " << *Lock << "\n");
@@ -303,10 +303,10 @@ void LockOwnershipInfo::buildSummary(const Function *F, bool InstrToLockFlag) {
   const LockStateTy &EntryState = InStates[&EntryBB];
   SmallPtrSet<const Value *, 4> &MayUnlock = FuncStateIt->second.MayUnlock;
   SmallPtrSet<const Value *, 4> &MustLock = FuncStateIt->second.MustLock;
-  
+
   MayUnlock.clear();
   MustLock.clear();
-  
+
   // MayUnlock: Locks that are locked at entry but not locked at exit
   for (const auto &[Lock, State] : EntryState) {
     if (State.IsLocked) {
@@ -318,7 +318,7 @@ void LockOwnershipInfo::buildSummary(const Function *F, bool InstrToLockFlag) {
       }
     }
   }
-  
+
   // MustLock: Locks that are locked at exit but were not locked at entry
   for (const auto &[Lock, State] : ExitState) {
     if (State.IsLocked) {


### PR DESCRIPTION
Replaces full exit state propagation at call sites with precise lock summaries tracking which locks a function may release and which it must acquire.

## Changes

- **Data structures**: Extended `FuncStateTy` with `MayUnlock` and `MustLock` sets
  - `MayUnlock`: Locks held at entry but not at exit (released on some path)
  - `MustLock`: Locks held at exit but not at entry (newly acquired on all paths)

- **Summary computation**: In `buildSummary()`, compute summaries by comparing entry and exit states
  - Handles both absent locks and explicitly unlocked locks in state maps
  
- **Call edge handling**: In `applyTransferFunc()`, apply summaries instead of full exit state
  - Remove locks in callee's `MayUnlock` from current lockset
  - Add locks in callee's `MustLock` to current lockset

## Example

```cpp
// Before: Replaced entire lockset with callee's exit state
for (const auto &[Lock, State] : FuncStateIt->second.ExitState) {
  if (State.IsLocked) handleLock(InState, I, Lock);
  else handleUnlock(InState, I, Lock);
}

// After: Selectively apply lock changes
for (const Value *Lock : FuncStateIt->second.MayUnlock) {
  if (InState.find(Lock) != InState.end())
    handleUnlock(InState, I, Lock);
}
for (const Value *Lock : FuncStateIt->second.MustLock) {
  handleLock(InState, I, Lock);
}
```

This enables more precise tracking of lock state changes across function boundaries, particularly for functions that partially modify the lockset.

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> 
> ----
> 
> *This section details on the original issue you should resolve*
> 
> <issue_title>Use lock summaries in `LockOwnership.cpp`</issue_title>
> <issue_description>Make a PR against the branch `tsan-with-ea-IPA`. In this PR, on top of computing the currently held lockset, for each procedure also compute a summary consisting of two sets:
> 
> - A set of mutexes that _may_ be unlocked anywhere in the function and not relocked
> - A set of mutexes that were not known to locked at the start of the function but are known to be locked now.
> 
> Then, we computing the effect of a call edge to `f`, take the current lockset, remove any mutexes that `f` may unlock and add those that `f` must lock.</issue_description>
> 
> ## Comments on the Issue (you are @copilot in this section)
> 
> <comments>
> </comments>
> 


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes michael-schwarz/llvm-project#1

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/michael-schwarz/llvm-project/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
